### PR TITLE
Setup CI with coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run tests
+        run: cargo test --all --verbose
+      - name: Generate coverage
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          args: --out Xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: cobertura.xml
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 <p>&nbsp;</p>
 
+[![CI](https://github.com/broadinstitute/poasta/actions/workflows/ci.yml/badge.svg)](https://github.com/broadinstitute/poasta/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/broadinstitute/poasta/branch/main/graph/badge.svg)](https://codecov.io/gh/broadinstitute/poasta)
+
+
 POASTA is a fast and optimal partial order aligner that supports gap-affine alignment penalties. Inspired by 
 a recent [algorithm for pairwise alignment](https://github.com/smarco/WFA2-lib), it can exploit exact matches
 between the query and the graph, greatly speeding up the alignment process.


### PR DESCRIPTION
## Summary
- setup GitHub Actions workflow running tests with tarpaulin
- upload coverage to Codecov
- add CI and Codecov badges to README

## Testing
- `cargo test --all --verbose` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_6867fcc78b308333ad3729684eafd53d