### PR TITLE
Add codex setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Setup script for the poasta repository.
+# Installs Rust if not present and builds the project in release mode.
+set -euo pipefail
+
+if ! command -v cargo >/dev/null; then
+    echo "Installing Rust toolchain" >&2
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    source "$HOME/.cargo/env"
+fi
+
+cargo build --release


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` that installs Rust if needed and builds the repo

## Testing
- `cargo test` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_6867fe43da988333b0579214ac724373