### PR TITLE
Fix CI coverage step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Generate coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: "0.26.0"
+          version: "v0.26.0"
           args: --out Xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Generate coverage
         run: cargo tarpaulin --out Xml
       - name: Upload coverage to Codecov
+        if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v3
         with:
           files: cobertura.xml
           fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Generate coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: "0.26.0"
           args: --out Xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,10 @@ jobs:
           override: true
       - name: Run tests
         run: cargo test --all --verbose
+      - name: Install tarpaulin
+        run: cargo install cargo-tarpaulin --version 0.26.0 --locked
       - name: Generate coverage
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: "v0.26.0"
-          args: --out Xml
+        run: cargo tarpaulin --out Xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Generate coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: "v0.26.0"
+          version: "0.26.0"
           args: --out Xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Summary
- pin tarpaulin version to avoid missing release

## Testing
- `cargo test --all --offline --quiet` *(fails: no matching package named `anyhow` found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fe9418288333a92c5408792a028c