### PR TITLE
Add clippy and test hooks to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,13 @@ repos:
         entry: cargo fmt -- --check
         language: system
         types: [rust]
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy -- -D warnings
+        language: system
+        types: [rust]
+      - id: cargo-test
+        name: cargo test
+        entry: cargo test
+        language: system
+        types: [rust]


### PR DESCRIPTION
## Summary
- extend pre-commit with `cargo clippy` and `cargo test`

## Testing
- `cargo clippy -- -D warnings` *(fails: component missing)*
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686836a6d5f48333979b99a9d4eaf1c9