### PR TITLE
Add ascii_radix feature for hex parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ rustc-hash = "1.1.0"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "1.0.99", features = ["std"] }
 smallvec = { version ="1.11.0", features =  ["const_generics", "union", "serde"] }
+
+[features]
+ascii_radix = []


### PR DESCRIPTION
## Summary
- add `ascii_radix` feature to Cargo manifest
- switch GFA byte array parsing to optional `u8::from_ascii_radix`
- keep previous `from_str_radix` code as fallback

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_686836e45ff48333974149678a86021d