### PR TITLE
Add clippy to setup

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -9,4 +9,6 @@ if ! command -v cargo >/dev/null; then
     source "$HOME/.cargo/env"
 fi
 
+rustup component add clippy
+cargo clippy --all-targets -- -D warnings
 cargo build --release


### PR DESCRIPTION
## Summary
- run `rustup component add clippy` and execute `cargo clippy` in `.codex/setup.sh`

## Testing
- `cargo test` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6868392fde3c8333ab02b466097d873c