### PR TITLE
Add tests for DFA extension logic

### DIFF
--- a/src/aligner/dfa.rs
+++ b/src/aligner/dfa.rs
@@ -131,6 +131,10 @@ where
         self.num_visited
     }
 
+    pub fn get_num_pruned(&self) -> usize {
+        self.num_pruned
+    }
+
     pub fn extend<V>(
         &mut self,
         astar_visited: &mut V,
@@ -256,5 +260,225 @@ where
     Match(AlignmentGraphNode<N, O>),
     Mismatch(AlignmentGraphNode<N, O>),
     SuccessorsExhausted,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graphs::mock::{create_test_graph1, MockGraph, NIx};
+    use crate::aligner::alignment::Alignment;
+    use rustc_hash::FxHashMap;
+    use std::fmt::Write;
+    use petgraph::graph::NodeIndex;
+    use nonmax::NonMaxU32;
+    use crate::errors::PoastaError;
+
+    struct SymbolMockGraph {
+        graph: MockGraph,
+        symbols: FxHashMap<NodeIndex<NIx>, u8>,
+    }
+
+    impl SymbolMockGraph {
+        fn new(graph: MockGraph, symbols: FxHashMap<NodeIndex<NIx>, u8>) -> Self {
+            Self { graph, symbols }
+        }
+    }
+
+    impl AlignableRefGraph for SymbolMockGraph {
+        type NodeIndex = NodeIndex<NIx>;
+        type NodeIterator<'a> = <MockGraph as AlignableRefGraph>::NodeIterator<'a>;
+        type PredecessorIterator<'a> = <MockGraph as AlignableRefGraph>::PredecessorIterator<'a>;
+        type SuccessorIterator<'a> = <MockGraph as AlignableRefGraph>::SuccessorIterator<'a>;
+
+        fn all_nodes(&self) -> Self::NodeIterator<'_> {
+            self.graph.all_nodes()
+        }
+
+        fn node_count(&self) -> usize {
+            self.graph.node_count()
+        }
+
+        fn node_count_with_start_and_end(&self) -> usize {
+            self.graph.node_count_with_start_and_end()
+        }
+
+        fn edge_count(&self) -> usize {
+            self.graph.edge_count()
+        }
+
+        fn start_node(&self) -> Self::NodeIndex {
+            self.graph.start_node()
+        }
+
+        fn end_node(&self) -> Self::NodeIndex {
+            self.graph.end_node()
+        }
+
+        fn predecessors(&self, node: Self::NodeIndex) -> Self::PredecessorIterator<'_> {
+            self.graph.predecessors(node)
+        }
+
+        fn successors(&self, node: Self::NodeIndex) -> Self::SuccessorIterator<'_> {
+            self.graph.successors(node)
+        }
+
+        fn in_degree(&self, node: Self::NodeIndex) -> usize {
+            self.graph.in_degree(node)
+        }
+
+        fn out_degree(&self, node: Self::NodeIndex) -> usize {
+            self.graph.out_degree(node)
+        }
+
+        fn is_end(&self, node: Self::NodeIndex) -> bool {
+            self.graph.is_end(node)
+        }
+
+        fn get_symbol_char(&self, node: Self::NodeIndex) -> char {
+            char::from(*self.symbols.get(&node).unwrap_or(&b'-'))
+        }
+
+        fn is_symbol_equal(&self, node: Self::NodeIndex, symbol: u8) -> bool {
+            self.symbols.get(&node).copied() == Some(symbol)
+        }
+
+        fn get_node_ordering(&self) -> Vec<usize> {
+            self.graph.get_node_ordering()
+        }
+    }
+
+    #[derive(Default)]
+    struct DummyVisited {
+        prune_next: bool,
+    }
+
+    impl DummyVisited {
+        fn new(prune_next: bool) -> Self {
+            Self { prune_next }
+        }
+    }
+
+    impl<N, O> AstarVisited<N, O> for DummyVisited
+    where
+        N: NodeIndexType,
+        O: OffsetType,
+    {
+        fn get_score(&self, _aln_node: &AlignmentGraphNode<N, O>, _aln_state: AlignState) -> Score {
+            Score::Unvisited
+        }
+
+        fn set_score(&mut self, _aln_node: &AlignmentGraphNode<N, O>, _aln_state: AlignState, _score: Score) {}
+
+        fn mark_reached(&mut self, _score: Score, _aln_node: &AlignmentGraphNode<N, O>, _aln_state: AlignState) {}
+
+        fn dfa_match(&mut self, _score: Score, _parent: &AlignmentGraphNode<N, O>, _child: &AlignmentGraphNode<N, O>) {}
+
+        fn prune(&self, _score: Score, _aln_node: &AlignmentGraphNode<N, O>, _aln_state: AlignState) -> bool {
+            self.prune_next
+        }
+
+        fn update_score_if_lower(
+            &mut self,
+            _aln_node: &AlignmentGraphNode<N, O>,
+            _aln_state: AlignState,
+            _parent: &AlignmentGraphNode<N, O>,
+            _parent_state: AlignState,
+            _score: Score,
+        ) -> bool {
+            true
+        }
+
+        fn backtrace<G>(&self, _ref_graph: &G, _seq: &[u8], _aln_node: &AlignmentGraphNode<N, O>) -> Alignment<N>
+        where
+            G: AlignableRefGraph<NodeIndex = N>,
+        {
+            Vec::new()
+        }
+
+        fn write_tsv<W: Write>(&self, _writer: &mut W) -> Result<(), PoastaError> {
+            Ok(())
+        }
+    }
+
+    fn setup_graph() -> SymbolMockGraph {
+        let graph = create_test_graph1();
+        let mut symbols: FxHashMap<NodeIndex<NIx>, u8> = FxHashMap::default();
+
+        let chars = [b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T', b'A', b'N'];
+        for (i, node) in graph.node_indices().enumerate() {
+            symbols.insert(node, chars[i]);
+        }
+
+        SymbolMockGraph::new(graph, symbols)
+    }
+
+    fn start_state(graph: &SymbolMockGraph, offset: u8) -> AlignmentGraphNode<NodeIndex<NIx>, u8> {
+        AlignmentGraphNode::new(graph.start_node(), offset)
+    }
+
+    #[test]
+    fn returns_mismatch_variant() {
+        let graph = setup_graph();
+        let seq = b"AA";
+        let start = start_state(&graph, 0);
+        let mut dfa = DepthFirstGreedyAlignment::new(&graph, seq, Score::Score(NonMaxU32::new(0).unwrap()), &start);
+        let mut visited = DummyVisited::new(false);
+
+        let res = dfa.extend(&mut visited);
+        if let Some(ExtendResult::Mismatch(parent, child)) = res {
+            assert_eq!(parent.node(), graph.start_node());
+            assert_eq!(parent.offset(), 1u8);
+            assert_eq!(child.node(), graph.successors(graph.start_node()).next().unwrap());
+            assert_eq!(child.offset(), 2u8);
+        } else {
+            panic!("unexpected result: {:?}", res);
+        }
+        assert_eq!(dfa.get_num_visited(), 1);
+        assert_eq!(dfa.get_num_pruned(), 0);
+    }
+
+    #[test]
+    fn returns_query_end_variant() {
+        let graph = setup_graph();
+        let seq = b"AC";
+        let start = start_state(&graph, 0);
+        let mut dfa = DepthFirstGreedyAlignment::new(&graph, seq, Score::Score(NonMaxU32::new(0).unwrap()), &start);
+        let mut visited = DummyVisited::new(false);
+
+        let res = dfa.extend(&mut visited);
+        if let Some(ExtendResult::QueryEnd(parent, child)) = res {
+            assert_eq!(parent.offset(), 2u8);
+            assert_eq!(child, graph.successors(parent.node()).next().unwrap());
+        } else {
+            panic!("unexpected result: {:?}", res);
+        }
+        assert_eq!(dfa.get_num_visited(), 2);
+    }
+
+    #[test]
+    fn returns_ref_graph_end_variant() {
+        let graph = setup_graph();
+        let seq = b"A";
+        let start = AlignmentGraphNode::new(graph.graph.node_indices().nth(5).unwrap(), 0u8);
+        let mut dfa = DepthFirstGreedyAlignment::new(&graph, seq, Score::Score(NonMaxU32::new(0).unwrap()), &start);
+        let mut visited = DummyVisited::new(false);
+
+        let res = dfa.extend(&mut visited);
+        assert!(matches!(res, Some(ExtendResult::RefGraphEnd(_, _))));
+        assert_eq!(dfa.get_num_visited(), 0);
+    }
+
+    #[test]
+    fn counts_pruned_states() {
+        let graph = setup_graph();
+        let seq = b"AC";
+        let start = start_state(&graph, 0);
+        let mut dfa = DepthFirstGreedyAlignment::new(&graph, seq, Score::Score(NonMaxU32::new(0).unwrap()), &start);
+        let mut visited = DummyVisited::new(true);
+
+        let res = dfa.extend(&mut visited);
+        assert!(res.is_none());
+        assert_eq!(dfa.get_num_pruned(), 1);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add `get_num_pruned` accessor
- create a mock graph wrapper with symbols for deterministic DFA tests
- verify `extend` behaviour for mismatch, query end, ref graph end and pruning

## Testing
- `cargo test --lib --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68683c53c61c8333924f354fda1d795a