### PR TITLE
Add integration tests for CLI binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,8 @@ smallvec = { version ="1.11.0", features =  ["const_generics", "union", "serde"]
 
 [features]
 ascii_radix = []
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.1"
+tempfile = "3.10"

--- a/tests/cli_lasagna.rs
+++ b/tests/cli_lasagna.rs
@@ -1,0 +1,22 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+#[test]
+fn lasagna_requires_subcommand() {
+    Command::cargo_bin("lasagna")
+        .unwrap()
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No subcommand"));
+}
+
+#[test]
+fn lasagna_align_gaf_output() {
+    Command::cargo_bin("lasagna")
+        .unwrap()
+        .args(["align", "tests/test.gfa", "tests/small_test.fa"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("seq1"));
+}

--- a/tests/cli_poasta.rs
+++ b/tests/cli_poasta.rs
@@ -1,0 +1,42 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn poasta_requires_subcommand() {
+    Command::cargo_bin("poasta")
+        .unwrap()
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No subcommand"));
+}
+
+#[test]
+fn poasta_align_fasta_stdout() {
+    Command::cargo_bin("poasta")
+        .unwrap()
+        .args(["align", "-O", "fasta", "tests/small_test.fa"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(">seq1"));
+}
+
+#[test]
+fn poasta_align_and_view_gfa() {
+    let dir = tempdir().unwrap();
+    let out = dir.path().join("graph.poasta");
+
+    Command::cargo_bin("poasta")
+        .unwrap()
+        .args(["align", "-o", out.to_str().unwrap(), "tests/small_test.fa"])
+        .assert()
+        .success();
+
+    Command::cargo_bin("poasta")
+        .unwrap()
+        .args(["view", out.to_str().unwrap(), "-O", "gfa"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("S\t"));
+}


### PR DESCRIPTION
## Summary
- add `assert_cmd` and helpers for testing binaries
- create integration tests for `poasta` and `lasagna`

## Testing
- `cargo fmt -- --check` *(fails: 'cargo-fmt' not installed)*
- `cargo test` *(fails: failed to get `ahash` as a dependency due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68683c55ed4083338dbad59ad6680410