### PR TITLE
Fix duplicate test module

### DIFF
--- a/src/io/gaf.rs
+++ b/src/io/gaf.rs
@@ -72,7 +72,7 @@ pub struct GAFRecord {
 }
 
 #[cfg(test)]
-mod tests {
+mod node_segment_resolver_tests {
     use super::*;
     use crate::graphs::poa::POAGraph;
     use crate::graphs::AlignableRefGraph;


### PR DESCRIPTION
## Summary
- rename `tests` module for NodeSegmentResolver

## Testing
- `cargo test --all --offline` *(fails: failed to download `assert_cmd`)*

------
https://chatgpt.com/codex/tasks/task_e_68685655fc6883338d7c7d16f2c4ab91