### PR TITLE
Add testing commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,3 +225,16 @@ GAF without producing a POASTA graph file.
 
 * [poa-bench](https://github.com/broadinstitute/poa-bench) - Benchmark POASTA against other POA tools
 * [spoa-rs](https://github.com/broadinstitute/spoa-rs) - Rust bindings to SPOA
+
+## Contributing
+
+Run the test suites to ensure everything works as expected.
+
+```bash
+cargo test
+pytest tests/python_tools
+```
+
+Both suites should pass. Set the `SEED` environment variable to force
+deterministic behavior. If you measure coverage, tools such as
+`cargo tarpaulin` or `pytest --cov` are recommended.


### PR DESCRIPTION
## Summary
- document how to run Rust and Python tests
- add note about deterministic runs via `SEED`
- mention optional coverage tools

## Testing
- `cargo test` *(fails: unable to fetch crates)*
- `pytest tests/python_tools`

------
https://chatgpt.com/codex/tasks/task_e_68685d06d4608333b9c72b05e4aa8da3